### PR TITLE
feat: mover gostosa, gostoso e delicia para CONTEXT_SENSITIVE

### DIFF
--- a/__tests__/filter.test.ts
+++ b/__tests__/filter.test.ts
@@ -117,6 +117,14 @@ describe('pau/rola/cacete as context-sensitive', () => {
   it('blocks "voce e um caralho" (directed)', () => expect(filterContent('voce e um caralho').allowed).toBe(false));
 });
 
+describe('gostosa/gostoso/delicia as context-sensitive', () => {
+  it('allows "comida gostosa"', () => expect(filterContent('comida gostosa').allowed).toBe(true));
+  it('allows "dia gostoso"', () => expect(filterContent('dia gostoso').allowed).toBe(true));
+  it('allows "que delicia de bolo"', () => expect(filterContent('que delicia de bolo').allowed).toBe(true));
+  it('blocks "sua gostosa" (directed)', () => expect(filterContent('sua gostosa').allowed).toBe(false));
+  it('blocks "voce e uma delicia" (directed)', () => expect(filterContent('voce e uma delicia').allowed).toBe(false));
+});
+
 // ─── Phone number blocking ───────────────────────────────────────────────────
 
 describe('phone number blocking', () => {

--- a/scripts/validate-wordlists.ts
+++ b/scripts/validate-wordlists.ts
@@ -37,12 +37,14 @@ function findCrossListDuplicates(
 function validateAbbreviations(): void {
   const abbrevKeys = Object.keys(ABBREVIATION_MAP);
 
-  // Check if abbreviation keys that are in HARD_BLOCKED also expand to something in HARD_BLOCKED
-  // (this is expected — just informational)
+  // Check if abbreviation expands to something in HARD_BLOCKED or CONTEXT_SENSITIVE
   const hardSet = new Set(HARD_BLOCKED.map(w => w.toLowerCase().trim()));
+  const contextSet = new Set(CONTEXT_SENSITIVE.map(w => w.toLowerCase().trim()));
   for (const [abbr, expansion] of Object.entries(ABBREVIATION_MAP)) {
-    if (!hardSet.has(abbr) && !hardSet.has(expansion)) {
-      console.warn(`  ⚠ Abreviação "${abbr}" → "${expansion}": nenhum dos dois está em HARD_BLOCKED`);
+    const inHard = hardSet.has(abbr) || hardSet.has(expansion);
+    const inContext = contextSet.has(abbr) || contextSet.has(expansion);
+    if (!inHard && !inContext) {
+      console.warn(`  ⚠ Abreviação "${abbr}" → "${expansion}": não está em HARD_BLOCKED nem CONTEXT_SENSITIVE`);
     }
   }
 

--- a/src/wordlists.ts
+++ b/src/wordlists.ts
@@ -221,6 +221,9 @@ export const CONTEXT_SENSITIVE: string[] = [
   'cu',          // "recuar", contexto comum
   'pica',        // "pica-pau", "que pica" (que legal, regional)
   'caralho',     // "caralho!" como exclamacao de surpresa
+  // Movidos de abbreviation warnings (contexto inocente comum)
+  'gostosa', 'gostoso',  // "comida gostosa", "dia gostoso"
+  'delicia',              // "que delicia de bolo"
 ];
 
 /** Padrões que indicam fala dirigida a outra pessoa (2ª pessoa). */


### PR DESCRIPTION
Palavras como "gostosa" e "delicia" tem uso inocente comum ("comida gostosa", "que delicia de bolo") mas sao assedio quando dirigidas a alguem ("sua gostosa"). Movidas para context-sensitive para bloquear apenas no contexto dirigido.

Tambem atualiza o script de validacao para checar
CONTEXT_SENSITIVE alem de HARD_BLOCKED nas abreviacoes.