### PR TITLE
feat: níveis de severidade (block, warn, flag)

### DIFF
--- a/__tests__/filter.test.ts
+++ b/__tests__/filter.test.ts
@@ -657,3 +657,123 @@ describe('performance', () => {
     expect(elapsed).toBeLessThan(1000);
   });
 });
+
+// ─── Severity levels ─────────────────────────────────────────────────────────
+
+describe('severity levels', () => {
+  it('defaults to severity "block" for all reasons', () => {
+    const result = filterContent('viado');
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.severity).toBe('block');
+    }
+  });
+
+  it('returns severity "block" for default filter on all reason types', () => {
+    // hard_block
+    const r1 = filterContent('viado');
+    if (!r1.allowed) expect(r1.severity).toBe('block');
+
+    // directed_insult
+    const r2 = filterContent('você é um lixo');
+    if (!r2.allowed) expect(r2.severity).toBe('block');
+
+    // fuzzy_match
+    const r3 = filterContent('viadro');
+    if (!r3.allowed) expect(r3.severity).toBe('block');
+
+    // link
+    const r4 = filterContent('https://example.com');
+    if (!r4.allowed) expect(r4.severity).toBe('block');
+
+    // phone
+    const r5 = filterContent('21994709426');
+    if (!r5.allowed) expect(r5.severity).toBe('block');
+
+    // digits_only
+    const r6 = filterContent('55');
+    if (!r6.allowed) expect(r6.severity).toBe('block');
+
+    // offensive_emoji
+    const r7 = filterContent('🖕');
+    if (!r7.allowed) expect(r7.severity).toBe('block');
+  });
+
+  it('respects custom severity per reason', () => {
+    const filter = createFilter({
+      severity: {
+        hard_block: 'block',
+        directed_insult: 'warn',
+        fuzzy_match: 'flag',
+      },
+    });
+
+    const r1 = filter('viado');
+    expect(r1.allowed).toBe(false);
+    if (!r1.allowed) expect(r1.severity).toBe('block');
+
+    const r2 = filter('você é um lixo');
+    expect(r2.allowed).toBe(false);
+    if (!r2.allowed) expect(r2.severity).toBe('warn');
+
+    const r3 = filter('viadro');
+    expect(r3.allowed).toBe(false);
+    if (!r3.allowed) expect(r3.severity).toBe('flag');
+  });
+
+  it('uses "block" as default for unconfigured reasons', () => {
+    const filter = createFilter({
+      severity: { directed_insult: 'warn' },
+    });
+
+    // hard_block not configured → defaults to 'block'
+    const r1 = filter('viado');
+    if (!r1.allowed) expect(r1.severity).toBe('block');
+
+    // directed_insult configured → 'warn'
+    const r2 = filter('seu idiota');
+    if (!r2.allowed) expect(r2.severity).toBe('warn');
+  });
+
+  it('allowed results have no severity field', () => {
+    const filter = createFilter({ severity: { hard_block: 'warn' } });
+    const result = filter('oi tudo bem');
+    expect(result.allowed).toBe(true);
+    expect('severity' in result).toBe(false);
+  });
+
+  it('severity works with link/phone/digits/emoji reasons', () => {
+    const filter = createFilter({
+      severity: {
+        link: 'flag',
+        phone: 'warn',
+        digits_only: 'flag',
+        offensive_emoji: 'warn',
+      },
+    });
+
+    const r1 = filter('https://example.com');
+    if (!r1.allowed) expect(r1.severity).toBe('flag');
+
+    const r2 = filter('21994709426');
+    if (!r2.allowed) expect(r2.severity).toBe('warn');
+
+    const r3 = filter('55');
+    if (!r3.allowed) expect(r3.severity).toBe('flag');
+
+    const r4 = filter('🖕');
+    if (!r4.allowed) expect(r4.severity).toBe('warn');
+  });
+
+  it('severity works with suspicious_content reason', () => {
+    const filter = createFilter({
+      severity: { suspicious_content: 'flag' },
+    });
+
+    const r = filter('bola leite molhada duro jato');
+    if (!r.allowed) {
+      expect(r.reason).toBe('suspicious_content');
+      expect(r.severity).toBe('flag');
+    }
+  });
+});

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -12,7 +12,7 @@ import {
   OFFENSIVE_EMOJI_SEQUENCES,
   CONTEXT_SENSITIVE_EMOJIS,
 } from './wordlists';
-import type { FilterResult, CensorResult, ToxiBROptions } from './types';
+import type { FilterResult, CensorResult, ToxiBROptions, FilterReason, Severity } from './types';
 
 // ─── Homoglyph map (Cyrillic → Latin) ────────────────────────────────────────
 
@@ -161,7 +161,16 @@ export function createFilter(options: ToxiBROptions = {}) {
     blockPhones = true,
     blockDigitsOnly = true,
     blockEmojis = true,
+    severity: severityConfig = {},
   } = options;
+
+  function getSeverity(reason: FilterReason): Severity {
+    return severityConfig[reason] ?? 'block';
+  }
+
+  function makeResult(reason: FilterReason, matched: string): FilterResult {
+    return { allowed: false, reason, matched, severity: getSeverity(reason) };
+  }
 
   const allBlocked = [...HARD_BLOCKED, ...extraBlockedWords];
   const allContext = [...CONTEXT_SENSITIVE, ...extraContextWords];
@@ -191,39 +200,39 @@ export function createFilter(options: ToxiBROptions = {}) {
 
     // Layer 0: Censorship bypass detection — words with * or # between letters
     if (/\w[*#]+\w/.test(text)) {
-      return { allowed: false, reason: 'hard_block', matched: 'censorship bypass' };
+      return makeResult('hard_block', 'censorship bypass');
     }
 
     // Layer 0z: Pre-normalization exact matches (terms that break after leetspeak/normalization)
     if (/\bd4\b/i.test(text)) {
-      return { allowed: false, reason: 'hard_block', matched: 'd4' };
+      return makeResult('hard_block', 'd4');
     }
     if (/\d+\s*cm\b/i.test(text)) {
-      return { allowed: false, reason: 'hard_block', matched: 'medida cm' };
+      return makeResult('hard_block', 'medida cm');
     }
     if (/\b-18\b/.test(text)) {
-      return { allowed: false, reason: 'hard_block', matched: '-18' };
+      return makeResult('hard_block', '-18');
     }
 
     // Layer 0a: Block links/URLs
     if (blockLinks && LINK_REGEX.test(text)) {
-      return { allowed: false, reason: 'link', matched: 'link' };
+      return makeResult('link', 'link');
     }
 
     // Layer 0b: Block phone numbers
     if (blockPhones) {
       if (PHONE_REGEX.test(text)) {
-        return { allowed: false, reason: 'phone', matched: 'telefone' };
+        return makeResult('phone', 'telefone');
       }
       const totalDigits = text.replace(/\D/g, '').length;
       if (totalDigits >= 5) {
-        return { allowed: false, reason: 'phone', matched: 'telefone' };
+        return makeResult('phone', 'telefone');
       }
     }
 
     // Layer 0c: Block messages that are only digits
     if (blockDigitsOnly && /^\d+$/.test(text.trim())) {
-      return { allowed: false, reason: 'digits_only', matched: 'numero isolado' };
+      return makeResult('digits_only', 'numero isolado');
     }
 
     // Layer 0d: Offensive emojis (checked on raw text — normalization strips emojis)
@@ -234,14 +243,14 @@ export function createFilter(options: ToxiBROptions = {}) {
       // Always-blocked emojis
       for (const emoji of OFFENSIVE_EMOJIS) {
         if (emojiText.includes(emoji)) {
-          return { allowed: false, reason: 'offensive_emoji', matched: emoji };
+          return makeResult('offensive_emoji', emoji);
         }
       }
 
       // Always-blocked sequences
       for (const seq of OFFENSIVE_EMOJI_SEQUENCES) {
         if (emojiText.includes(seq)) {
-          return { allowed: false, reason: 'offensive_emoji', matched: seq };
+          return makeResult('offensive_emoji', seq);
         }
       }
 
@@ -249,7 +258,7 @@ export function createFilter(options: ToxiBROptions = {}) {
       for (const emoji of CONTEXT_SENSITIVE_EMOJIS) {
         if (!emojiText.includes(emoji)) continue;
         if (DIRECTED_PATTERNS.some(p => p.test(normalized))) {
-          return { allowed: false, reason: 'offensive_emoji', matched: emoji };
+          return makeResult('offensive_emoji', emoji);
         }
       }
     }
@@ -257,7 +266,7 @@ export function createFilter(options: ToxiBROptions = {}) {
     // Layer 1: Hard-blocked words
     for (const { word, regex } of hardBlockedRegexes) {
       if (regex.test(normalized)) {
-        return { allowed: false, reason: 'hard_block', matched: word };
+        return makeResult('hard_block', word);
       }
     }
 
@@ -274,7 +283,7 @@ export function createFilter(options: ToxiBROptions = {}) {
           for (const blocked of candidates) {
             const dist = levenshtein(msgWord, blocked, threshold);
             if (dist > 0 && dist <= threshold) {
-              return { allowed: false, reason: 'fuzzy_match', matched: blocked };
+              return makeResult('fuzzy_match', blocked);
             }
           }
         }
@@ -290,7 +299,7 @@ export function createFilter(options: ToxiBROptions = {}) {
         for (const blocked of prefixWords) {
           if (blocked.length < msgWord.length) continue;
           if (blocked.startsWith(msgWord) && msgWord.length >= blocked.length * 0.55) {
-            return { allowed: false, reason: 'hard_block', matched: blocked };
+            return makeResult('hard_block', blocked);
           }
         }
       }
@@ -341,7 +350,7 @@ export function createFilter(options: ToxiBROptions = {}) {
 
         // Directed is closer (or equal) than self-expression → block
         if (closestDirected < Infinity && closestDirected <= closestSelfExpr) {
-          return { allowed: false, reason: 'directed_insult', matched: word };
+          return makeResult('directed_insult', word);
         }
       }
 
@@ -359,11 +368,7 @@ export function createFilter(options: ToxiBROptions = {}) {
         const window = words.slice(i, i + windowSize);
         const seedMatches = window.filter(w => seedSet.has(w));
         if (seedMatches.length >= 3) {
-          return {
-            allowed: false,
-            reason: 'suspicious_content',
-            matched: seedMatches.join(', '),
-          };
+          return makeResult('suspicious_content', seedMatches.join(', '));
         }
       }
 
@@ -371,11 +376,7 @@ export function createFilter(options: ToxiBROptions = {}) {
       if (words.length < windowSize && words.length >= 3) {
         const seedMatches = words.filter(w => seedSet.has(w));
         if (seedMatches.length >= 3) {
-          return {
-            allowed: false,
-            reason: 'suspicious_content',
-            matched: seedMatches.join(', '),
-          };
+          return makeResult('suspicious_content', seedMatches.join(', '));
         }
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 // Biblioteca de moderação de conteúdo para português brasileiro.
 
 export { filterContent, createFilter, censorContent, createCensor, normalize } from './filter';
-export type { FilterResult, FilterReason, CensorResult, ToxiBROptions } from './types';
+export type { FilterResult, FilterReason, CensorResult, ToxiBROptions, Severity, SeverityConfig } from './types';
 export {
   HARD_BLOCKED,
   CONTEXT_SENSITIVE,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,10 @@
 export type FilterReason = 'hard_block' | 'directed_insult' | 'fuzzy_match' | 'suspicious_content' | 'link' | 'phone' | 'digits_only' | 'offensive_emoji';
 
+export type Severity = 'block' | 'warn' | 'flag';
+
 export type FilterResult =
   | { allowed: true }
-  | { allowed: false; reason: FilterReason; matched: string };
+  | { allowed: false; reason: FilterReason; matched: string; severity: Severity };
 
 export interface CensorResult {
   /** The censored text with blocked words replaced */
@@ -12,6 +14,9 @@ export interface CensorResult {
   /** List of words that were censored */
   matches: Array<{ word: string; reason: FilterReason; matched: string }>;
 }
+
+/** Severity configuration per FilterReason. Default: all 'block'. */
+export type SeverityConfig = Partial<Record<FilterReason, Severity>>;
 
 export interface ToxiBROptions {
   /** Additional words to hard-block (merged with built-in list). */
@@ -32,4 +37,6 @@ export interface ToxiBROptions {
   censorPhones?: boolean;
   /** Censor links instead of blocking. Default: false */
   censorLinks?: boolean;
+  /** Severity level per filter reason. Default: all 'block'. */
+  severity?: SeverityConfig;
 }


### PR DESCRIPTION
## Summary
- Adds `Severity` type (`'block' | 'warn' | 'flag'`) and `SeverityConfig` to configure severity per `FilterReason`
- New `severity` option in `ToxiBROptions` — each reason (hard_block, directed_insult, fuzzy_match, etc.) can be independently set
- `FilterResult` now includes a `severity` field when `allowed: false`
- Defaults to `'block'` for all reasons, maintaining full backward compatibility

## API
```typescript
const filter = createFilter({
  severity: {
    hard_block: 'block',
    directed_insult: 'warn',
    fuzzy_match: 'flag',
  },
});
```

## Test plan
- [x] All 678 existing tests pass (no regressions)
- [x] New tests for default severity on all reason types
- [x] Tests for custom severity configuration per reason
- [x] Tests for unconfigured reasons defaulting to 'block'
- [x] Tests for allowed results having no severity field
- [x] Tests for suspicious_content severity

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)