### PR TITLE
feat: ESM + CJS dual build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,24 @@
   "name": "toxibr",
   "version": "1.1.0",
   "description": "Biblioteca de moderação de conteúdo para português brasileiro. Filtro com wordlist 200+ termos, detecção context-aware, normalização anti-bypass e bloqueio de links/telefones.",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "npm run build:esm && npm run build:cjs && npm run build:types",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:types": "tsc -p tsconfig.types.json",
     "test": "jest",
     "validate": "ts-node scripts/validate-wordlists.ts",
     "build:demo": "esbuild src/browser.ts --bundle --minify --outfile=docs/toxibr.min.js --format=iife",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./dist/cjs",
+    "declaration": false
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "./dist/esm",
+    "declaration": false
+  }
+}

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/types",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  }
+}


### PR DESCRIPTION
## Summary
- Configure separate TypeScript builds for ESM (`dist/esm/`), CJS (`dist/cjs/`), and type declarations (`dist/types/`)
- Add `exports` map in `package.json` for proper module resolution in Node.js (CJS & ESM) and bundlers (webpack, vite)
- Add `tsconfig.esm.json`, `tsconfig.cjs.json`, and `tsconfig.types.json` build configs

Closes #7

## Test plan
- [x] `npm run build` succeeds — outputs to `dist/esm/`, `dist/cjs/`, `dist/types/`
- [x] ESM output uses `export` syntax, CJS uses `require`/`exports`
- [x] All 198 existing tests pass
- [x] Type declarations generated in `dist/types/`
- [x] Gzipped bundle size under 10KB (minified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)