### PR TITLE
feat: add batch filtering API

### DIFF
--- a/__tests__/filter.test.ts
+++ b/__tests__/filter.test.ts
@@ -1,4 +1,10 @@
-import { filterContent, normalize, createFilter } from '../src/filter';
+import {
+  filterContent,
+  normalize,
+  createFilter,
+  filterBatch,
+  createFilterBatch,
+} from '../src/filter';
 
 // ─── Normalization ───────────────────────────────────────────────────────────
 
@@ -820,5 +826,45 @@ describe('severity levels', () => {
       expect(r.reason).toBe('suspicious_content');
       expect(r.severity).toBe('flag');
     }
+  });
+});
+
+// ─── Batch filtering ─────────────────────────────────────────────────────────
+
+describe('filterBatch', () => {
+  it('returns one result per message', () => {
+    const results = filterBatch(['oi', 'tudo bem', 'hello']);
+    expect(results).toHaveLength(3);
+    results.forEach((r) => expect(r.allowed).toBe(true));
+  });
+
+  it('correctly filters mixed allowed/blocked messages', () => {
+    const results = filterBatch(['bom dia', 'seu idiota', 'tudo certo']);
+    expect(results).toHaveLength(3);
+    expect(results[0].allowed).toBe(true);
+    expect(results[1].allowed).toBe(false);
+    if (!results[1].allowed) {
+      expect(results[1].reason).toBe('directed_insult');
+    }
+    expect(results[2].allowed).toBe(true);
+  });
+
+  it('returns empty array for empty input', () => {
+    const results = filterBatch([]);
+    expect(results).toEqual([]);
+  });
+
+  it('produces same results as individual filterContent calls', () => {
+    const messages = ['oi amigo', 'vai tomar no cu', 'boa tarde', 'fdp'];
+    const batchResults = filterBatch(messages);
+    const individualResults = messages.map(filterContent);
+    expect(batchResults).toEqual(individualResults);
+  });
+
+  it('works with createFilterBatch and custom options', () => {
+    const batch = createFilterBatch({ blockLinks: false });
+    const results = batch(['http://example.com', 'seu idiota']);
+    expect(results[0].allowed).toBe(true);
+    expect(results[1].allowed).toBe(false);
   });
 });

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -611,6 +611,15 @@ export function createCensor(options: ToxiBROptions = {}) {
 
 export const censorContent = createCensor();
 
+// ─── Batch filtering ─────────────────────────────────────────────────────────
+
+export function createFilterBatch(options: ToxiBROptions = {}) {
+  const filter = createFilter(options);
+  return (messages: string[]): FilterResult[] => messages.map(filter);
+}
+
+export const filterBatch = createFilterBatch();
+
 // ─── Default filter (zero config) ────────────────────────────────────────────
 
 export const filterContent = createFilter();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,15 @@
 // ─── ToxiBR ──────────────────────────────────────────────────────────────────
 // Biblioteca de moderação de conteúdo para português brasileiro.
 
-export { filterContent, createFilter, censorContent, createCensor, normalize } from './filter';
+export {
+  filterContent,
+  createFilter,
+  filterBatch,
+  createFilterBatch,
+  censorContent,
+  createCensor,
+  normalize,
+} from './filter';
 export type {
   FilterResult,
   FilterReason,


### PR DESCRIPTION
## Summary
- Adds `filterBatch(messages: string[]): FilterResult[]` for filtering multiple messages at once
- Adds `createFilterBatch(options?)` factory for custom-configured batch filtering
- Reuses a single filter instance per batch to avoid recompiling regexes on each call

Closes #6

## Test plan
- [x] Returns one result per message
- [x] Correctly identifies mixed allowed/blocked messages
- [x] Returns empty array for empty input
- [x] Produces identical results to individual `filterContent` calls
- [x] Works with custom options via `createFilterBatch`
- [x] All 207 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)