### PR TITLE
fix: bloqueie/roda false positives

### DIFF
--- a/__tests__/filter.test.ts
+++ b/__tests__/filter.test.ts
@@ -432,6 +432,8 @@ describe('false positives — new v2 additions must not break', () => {
     'o dp do predio avisou',
     'pinto de ovo caipira',
     'eu pinto a parede amanha',
+    'Bloqueie palavras e ofensas usando contexto',
+    'nada de SDK pesado, roda em qualquer lugar',
   ];
 
   safe.forEach((phrase) => {

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -271,6 +271,8 @@ const FUZZY_ALLOWLIST = new Set([
   'torno', // → corno
   'ponta',
   'pontas', // → phnta
+  'bloqueie', // → boquete
+  'roda', // prefix matches rodada
 ]);
 
 // ─── Escape regex special chars ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `bloqueie` to FUZZY_ALLOWLIST (was fuzzy-matching `boquete`)
- Add `roda` to FUZZY_ALLOWLIST (was prefix-matching `rodada`)
- Add test cases for both words

Closes #30

## Test plan
- [x] All 705 tests pass
- [x] New test cases verify "Bloqueie palavras e ofensas" and "roda em qualquer lugar" are allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)