### PR TITLE
feat: add 'mascote de petrolífera' to racism blocklist

### DIFF
--- a/__tests__/filter.test.ts
+++ b/__tests__/filter.test.ts
@@ -82,6 +82,16 @@ describe('hard-blocked words', () => {
   });
 });
 
+// ─── Racismo ─────────────────────────────────────────────────────────────────
+
+describe('hard-blocked — racism terms', () => {
+  it('blocks "mascote de petrolífera"', () => {
+    const result = filterContent('aquele cara é mascote de petrolífera');
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) expect(result.reason).toBe('hard_block');
+  });
+});
+
 // ─── New slurs added in v2 ───────────────────────────────────────────────────
 
 describe('hard-blocked — new slurs (v2)', () => {

--- a/src/wordlists.ts
+++ b/src/wordlists.ts
@@ -337,6 +337,7 @@ export const HARD_BLOCKED: string[] = [
   'neguinho', 'neguinha',
   'preto imundo', 'preta imunda',
   'bola gato',
+  'mascote de petrolifera',
 
   // ── Nazismo / fascismo / supremacia ──
   'nazi', 'nazista', 'nazismo', 'neonazi', 'neonazista', 'neonazismo',


### PR DESCRIPTION
## Summary
- Adds "mascote de petrolífera" to the `HARD_BLOCKED` racism category (closes #39)
- Adds test case for the new term

## Test plan
- [x] `npm test` — all 210 tests pass
- [x] `npm run validate` — no duplicates found
- [x] `npm run format` — code formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)