### PR TITLE
fix: resolve Issue #42 atualizando wordlist, normalização e removendo duplicatas

### DIFF
--- a/__tests__/filter.test.ts
+++ b/__tests__/filter.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, test } from '@jest/globals';
 import {
   filterContent,
   normalize,
@@ -878,5 +879,377 @@ describe('filterBatch', () => {
     const results = batch(['http://example.com', 'seu idiota']);
     expect(results[0].allowed).toBe(true);
     expect(results[1].allowed).toBe(false);
+  });
+});
+
+// ─── Issue #37 — Bypass com números não-leet e emojis ────────────────────────
+
+describe('Issue #37 — numeric bypass (digits 2, 6, 8, 9 as separators)', () => {
+  describe('bypass bloqueado', () => {
+    it('blocks v2ado (viado com 2)', () => {
+      const result = filterContent('v2ado');
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) expect(result.reason).toBe('hard_block');
+    });
+
+    it('blocks vi6do (viado com 6)', () => {
+      const result = filterContent('vi6do');
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) expect(result.reason).toBe('hard_block');
+    });
+
+    it('blocks pu9a (puta com 9)', () => {
+      const result = filterContent('pu9a');
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) expect(result.reason).toBe('hard_block');
+    });
+
+    it('blocks bu6eta (buceta com 6)', () => {
+      const result = filterContent('bu6eta');
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) expect(result.reason).toBe('hard_block');
+    });
+
+    it('blocks vi8do (viado com 8)', () => {
+      const result = filterContent('vi8do');
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) expect(result.reason).toBe('hard_block');
+    });
+
+    it('blocks pu2ta (puta com 2)', () => {
+      const result = filterContent('pu2ta');
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) expect(result.reason).toBe('hard_block');
+    });
+  });
+
+  describe('falsos positivos numéricos — devem passar (CONTENT CLEAN)', () => {
+    it('allows ps5 (console)', () => {
+      expect(filterContent('comprei um ps5').allowed).toBe(true);
+    });
+
+    it('allows b2b (business to business)', () => {
+      expect(filterContent('estrategia b2b').allowed).toBe(true);
+    });
+
+    it('allows 2x1 (promoção)', () => {
+      expect(filterContent('oferta 2x1').allowed).toBe(true);
+    });
+
+    it('allows h2o (química)', () => {
+      expect(filterContent('beba h2o').allowed).toBe(true);
+    });
+
+    it('allows co2 (dióxido de carbono)', () => {
+      expect(filterContent('emissoes de co2').allowed).toBe(true);
+    });
+  });
+});
+
+describe('Issue #37 — emoji bypass (emojis como separadores dentro de palavras)', () => {
+  describe('bypass bloqueado', () => {
+    it('blocks v🍑ado (viado com emoji pêssego)', () => {
+      const result = filterContent('v🍑ado');
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) expect(result.reason).toBe('hard_block');
+    });
+
+    it('blocks pu🍑ta (puta com emoji pêssego)', () => {
+      const result = filterContent('pu🍑ta');
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) expect(result.reason).toBe('hard_block');
+    });
+
+    it('blocks vi🍆do (viado com emoji berinjela)', () => {
+      const result = filterContent('vi🍆do');
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) expect(result.reason).toBe('hard_block');
+    });
+
+    it('blocks bu🌸eta (buceta com emoji flor)', () => {
+      const result = filterContent('bu🌸eta');
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) expect(result.reason).toBe('hard_block');
+    });
+
+    it('blocks ar💢ombado (arrombado com emoji)', () => {
+      const result = filterContent('ar💢ombado');
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) expect(result.reason).toBe('hard_block');
+    });
+  });
+
+  describe('falsos positivos com emojis — devem passar (CONTENT CLEAN)', () => {
+    it('allows "valeu! 😊" (emoji no final da frase)', () => {
+      expect(filterContent('valeu! 😊').allowed).toBe(true);
+    });
+
+    it('allows "boa noite 🌙" (emoji separado do texto)', () => {
+      expect(filterContent('boa noite 🌙').allowed).toBe(true);
+    });
+
+    it('allows "oi! 😊👋" (emojis após pontuação)', () => {
+      expect(filterContent('oi! 😊👋').allowed).toBe(true);
+    });
+
+    it('allows "parabéns! 🎉🎂" (emojis festivos)', () => {
+      expect(filterContent('parabéns! 🎉🎂').allowed).toBe(true);
+    });
+
+    it('allows emoji with only 1 letter on each side (a😊b — não é bypass)', () => {
+      // Apenas 1 letra em cada lado do emoji — não atinge o limite de 2 letras
+      expect(filterContent('a😊b').allowed).toBe(true);
+    });
+  });
+});
+
+describe('Issue #37 — leetspeak legítimo (0, 1, 3, 4, 5, 7) continua funcionando via Layer de tradução', () => {
+  it('blocks 3stupr0 (estupro com leet 3→e, 0→o)', () => {
+    const result = filterContent('3stupr0');
+    expect(result.allowed).toBe(false);
+  });
+
+  it('blocks v14do (viado com leet 1→i, 4→a)', () => {
+    const result = filterContent('v14do');
+    expect(result.allowed).toBe(false);
+  });
+
+  it('blocks 3stup4dor (estuprador com leet)', () => {
+    const result = filterContent('3stup4dor');
+    expect(result.allowed).toBe(false);
+  });
+
+  it('blocks bu53t4 (buceta com leet 5→s, 3→e, 4→a)', () => {
+    const result = filterContent('bu53t4');
+    expect(result.allowed).toBe(false);
+  });
+
+  it('normalize translates leet digits correctly', () => {
+    expect(normalize('v14do')).toContain('viado');
+    expect(normalize('3stupr0')).toContain('estupr');
+    expect(normalize('bu53t4')).toContain('buseta');
+  });
+});
+
+// ─── Issue #42 — 10 Termos Não Capturados ────────────────────────────────────
+
+describe('[Issue #42] - 10 Termos Reportados', () => {
+  // ── pornografia ────────────────────────────────────────────────────────────
+
+  describe('pornografia — variantes de bypass', () => {
+    it('blocks p0rn0gr4f14 (leet: 0→o, 4→a)', () => {
+      const result = filterContent('p0rn0gr4f14');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('blocks p*rn*gr*f** (Layer 0: * entre letras)', () => {
+      const result = filterContent('p*rn*gr*f**');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('blocks p0rn0gr@f14 (@ → a via leet + 0→o, 1→i, 4→a)', () => {
+      const result = filterContent('p0rn0gr@f14');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('normalize converte p0rn0gr4f14 para pornografia', () => {
+      expect(normalize('p0rn0gr4f14')).toContain('pornografia');
+    });
+  });
+
+  // ── tarado ─────────────────────────────────────────────────────────────────
+
+  describe('tarado — variantes de bypass', () => {
+    it('blocks t4r4d0 (leet: 4→a, 0→o)', () => {
+      const result = filterContent('t4r4d0');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('blocks t@r@d0 (Layer 0: @ como separador)', () => {
+      const result = filterContent('t@r@d0');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('blocks t*r*d* (Layer 0: * entre letras)', () => {
+      const result = filterContent('t*r*d*');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('normalize converte t4r4d0 para tarado', () => {
+      expect(normalize('t4r4d0')).toBe('tarado');
+    });
+  });
+
+  // ── adulto (context-sensitive) ─────────────────────────────────────────────
+
+  describe('adulto — variantes de bypass (context-sensitive)', () => {
+    it('blocks seu 4dult0 (leet 4→a, 0→o + contexto dirigido "seu")', () => {
+      const result = filterContent('seu 4dult0');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('blocks seu @dult0 (@ → a via leet + contexto dirigido)', () => {
+      const result = filterContent('seu @dult0');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('blocks "seu a*dult*o" (Layer 0: * entre letras)', () => {
+      // a*d → letra + * + letra → capturado pelo Layer 0
+      expect(filterContent('seu a*dult*o').allowed).toBe(false);
+    });
+
+    it('normalize converte 4dult0 para adulto', () => {
+      expect(normalize('4dult0')).toBe('adulto');
+    });
+
+    it('allows "adulto responsavel" (sem contexto dirigido — falso positivo prevenido)', () => {
+      expect(filterContent('adulto responsavel').allowed).toBe(true);
+    });
+  });
+
+  // ── cuzinho ────────────────────────────────────────────────────────────────
+
+  describe('cuzinho — variantes de bypass', () => {
+    it('blocks cuz1nh0 (leet: 1→i, 0→o)', () => {
+      const result = filterContent('cuz1nh0');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('blocks cuz!nh0 (! → i entre word chars, 0→o)', () => {
+      const result = filterContent('cuz!nh0');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('blocks cuz*nh* (Layer 0: * entre letras)', () => {
+      const result = filterContent('cuz*nh*');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('normalize converte cuz!nh0 para cuzinho', () => {
+      expect(normalize('cuz!nh0')).toBe('cuzinho');
+    });
+
+    it('normalize converte cuz1nh0 para cuzinho', () => {
+      expect(normalize('cuz1nh0')).toBe('cuzinho');
+    });
+
+    it('does NOT affect trailing ! in normal phrases (falso positivo prevenido)', () => {
+      // "valeu!" — o ! está no final, sem letra depois → não é convertido
+      expect(filterContent('valeu!').allowed).toBe(true);
+    });
+  });
+
+  // ── gozo ───────────────────────────────────────────────────────────────────
+
+  describe('gozo — variantes de bypass', () => {
+    it('blocks g0z0 (leet: 0→o)', () => {
+      const result = filterContent('g0z0');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('blocks g@z0 (Layer 0: @ como separador entre g e z)', () => {
+      // @ entre duas letras é detectado no Layer 0 como bypass
+      const result = filterContent('g@z0');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('blocks g*z* (Layer 0: * entre letras)', () => {
+      const result = filterContent('g*z*');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('normalize converte g0z0 para gozo', () => {
+      expect(normalize('g0z0')).toBe('gozo');
+    });
+  });
+
+  // ── punheteirinha / punheteirinho ──────────────────────────────────────────
+
+  describe('punheteirinha/punheteirinho — variantes de bypass', () => {
+    it('blocks punh3t31r1nh4 (leet para punheteirinha)', () => {
+      const result = filterContent('punh3t31r1nh4');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('blocks punh3t31r1nh0 (leet para punheteirinho)', () => {
+      const result = filterContent('punh3t31r1nh0');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('normalize converte punh3t31r1nh4 para punheteirinha', () => {
+      expect(normalize('punh3t31r1nh4')).toBe('punheteirinha');
+    });
+  });
+
+  // ── sexo ───────────────────────────────────────────────────────────────────
+
+  describe('sexo — variantes de bypass', () => {
+    it('blocks s3x0 (leet: 3→e, 0→o)', () => {
+      const result = filterContent('s3x0');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('blocks "sx" (abreviação via ABBREVIATION_MAP)', () => {
+      const result = filterContent('sx');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('normalize converte s3x0 para sexo', () => {
+      expect(normalize('s3x0')).toBe('sexo');
+    });
+  });
+
+  // ── abreviações novas (prn, sx, trd) ──────────────────────────────────────
+
+  describe('novas abreviações (Issue #42)', () => {
+    it('blocks "prn" (→ porno via ABBREVIATION_MAP)', () => {
+      expect(filterContent('prn').allowed).toBe(false);
+    });
+
+    it('blocks "trd" (→ tarado via ABBREVIATION_MAP)', () => {
+      expect(filterContent('trd').allowed).toBe(false);
+    });
+  });
+
+  // ── combinação: jogar um leite ─────────────────────────────────────────────
+
+  describe('"jogar um leite" — combinação deve ser capturada', () => {
+    it('blocks "jogar um leite" (frase hard-blocked)', () => {
+      const result = filterContent('jogar um leite');
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) expect(result.reason).toBe('hard_block');
+    });
+
+    it('blocks "vou jogar um leite" (frase com contexto)', () => {
+      expect(filterContent('vou jogar um leite').allowed).toBe(false);
+    });
+  });
+
+  // ── integridade: falsos positivos existentes não regridem ─────────────────
+
+  describe('regressao — falsos positivos nao devem ser quebrados', () => {
+    it('allows "oi! 😊" (! trailing — nao e bypass de i)', () => {
+      expect(filterContent('oi! 😊').allowed).toBe(true);
+    });
+
+    it('allows "valeu! 😊" (emoji apos pontuacao)', () => {
+      expect(filterContent('valeu! 😊').allowed).toBe(true);
+    });
+
+    it('allows "parabens! 🎉" (exclamacao no final)', () => {
+      expect(filterContent('parabens! 🎉').allowed).toBe(true);
+    });
+
+    it('allows "adulto responsavel" (adulto sem contexto dirigido)', () => {
+      expect(filterContent('adulto responsavel').allowed).toBe(true);
+    });
+
+    it('allows "jogar bola" (jogar sem conotacao sexual)', () => {
+      expect(filterContent('jogar bola').allowed).toBe(true);
+    });
+
+    it('allows "copo de leite" (leite em contexto inocente)', () => {
+      expect(filterContent('copo de leite').allowed).toBe(true);
+    });
   });
 });

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -162,6 +162,9 @@ export function normalize(input: string): string {
 
   // 8. Remove censoring characters (* #) between letters
   t = t.replace(/[*#]+/g, '');
+  // 8c. Convert ! used as bypass for 'i' — only when directly between word chars
+  //     Handles "cuz!nh0" → "cuzinho". Trailing/leading ! (e.g. "valeu!") is untouched.
+  t = t.replace(/(\w)!+(\w)/g, (_, a, b) => a + 'i' + b);
 
   // 8b. Remove dots/dashes between single chars (p.u.t.a → puta)
   t = t.replace(/(\w)[.\-](?=\w[.\-])/g, '$1');
@@ -249,7 +252,8 @@ const FUZZY_ALLOWLIST = new Set([
   'estouro', // fuzzy matches estuprar
   'jogou',
   'jogos',
-  'jogo', // fuzzy matches jorrou
+  'jogo',
+  'jogar', // fuzzy matches jorar (jorrar collapsed)
   'cama', // prefix matches cam4
   'video',
   'videos', // fuzzy matches xvideos
@@ -346,8 +350,20 @@ export function createFilter(options: ToxiBROptions = {}) {
   return function filterContent(text: string): FilterResult {
     const normalized = normalize(text);
 
-    // Layer 0: Censorship bypass detection — words with * or # between letters
-    if (/\w[*#]+\w/.test(text)) {
+    // Layer 0: Censorship bypass detection
+    // * or # between any two letters (p*ta, v#ado)
+    // @ between letters as bypass separator (g@z0, t@r@d0) — distinct from the
+    //   LEET map that converts @ → a for leet-style writes like t@r4d0.
+    // Non-leet digits 2,6,8,9 used as separators — require ≥2 letters on at
+    //   least one side so that technical terms like b2b / ps5 / 2x1 are allowed.
+    // Emojis used as separators within a word (v🍑ado) — same ≥2-letter rule.
+    const _emojiSepRe =
+      /[a-zA-Z]{2,}\p{Extended_Pictographic}[a-zA-Z]|[a-zA-Z]\p{Extended_Pictographic}[a-zA-Z]{2,}/u;
+    if (
+      /[a-zA-Z][*#@]+[a-zA-Z]/.test(text) ||
+      /[a-zA-Z]{2,}[2689]+[a-zA-Z]|[a-zA-Z][2689]+[a-zA-Z]{2,}/.test(text) ||
+      _emojiSepRe.test(text)
+    ) {
       return makeResult('hard_block', 'censorship bypass');
     }
 

--- a/src/wordlists.ts
+++ b/src/wordlists.ts
@@ -63,6 +63,10 @@ export const ABBREVIATION_MAP: Record<string, string> = {
   xrc: 'xereca',
   xib: 'xibiu',
   pz: 'pauzao',
+  // Issue #42 — novos termos
+  prn: 'porno',
+  sx: 'sexo',
+  trd: 'tarado',
 };
 
 /** Palavras SEMPRE bloqueadas, independente do contexto. */
@@ -104,6 +108,11 @@ export const HARD_BLOCKED: string[] = [
   'brasileirinhas',
 
   // ── Conteudo sexual explicito ──
+  // Issue #42 — termos não capturados
+  'tarado', 'tarada',
+  'cuzinho',
+  'gozo', 'gozos',
+  'sexo',
   'punheteiro', 'punheteira', 'punheteirinho', 'punheteirinha',
   'punheta', 'punhetao', 'punhetinha',
   'batendo uma', 'bora bater uma', 'bater uma', 'gozando',
@@ -159,6 +168,8 @@ export const HARD_BLOCKED: string[] = [
   'corno', 'cornudo', 'cornuda',
   'rabeta', 'gulosa', 'cunhete',
   'bunda', 'pauzao', 'fodido',
+  // Issue #42 — expansões de abreviações sem entrada em HARD_BLOCKED
+  'foda-se', 'puta que pariu', 'urach', 'bucetuda', 'fodendo', 'tesao',
 
   // ── Pedofilia / grooming ──
   'pedo', 'p3do', 'epstein',
@@ -272,7 +283,6 @@ export const HARD_BLOCKED: string[] = [
   'bilau',
   'peitos', 'peituda', 'peitudas',
   'tesuda', 'tesudas', 'tesudo', 'tezao', 'tezuda', 'tezudo',
-  'tarada',
   'safada', 'safadas', 'safado', 'safados',
   'rabuda', 'rabudas',
   'gostozudas', 'greludas',
@@ -429,6 +439,10 @@ export const CONTEXT_SENSITIVE: string[] = [
   'delicia',              // "que delicia de bolo"
   'dp',                 // "dp do prédio", "delegacia de polícia"
   'dupla penetracao',
+  // Issue #42 — context-sensitive: inocentes fora do contexto sexual dirigido
+  'adulto',   // "adulto responsavel" vs "conteudo adulto" dirigido
+  'leite',    // "copo de leite" vs conotacao sexual dirigida
+  'jogar',    // "jogar bola" vs "jogar leite" em contexto dirigido
 ];
 
 /** Emojis SEMPRE bloqueados (inequivocamente ofensivos). */
@@ -503,6 +517,8 @@ export const SEXUAL_SEED_WORDS: string[] = [
   'bafo', 'bambas', 'fundo', 'forca',
   'cachorra', 'arreganhada', 'esfolado',
   'squirt', 'melam', 'melou',
+  // Issue #42
+  'pornografia', 'tarado', 'sexo',
 ];
 
 /** Padrões que indicam fala dirigida a outra pessoa (2ª pessoa). */

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -28,15 +28,24 @@
       }
     },
     "..": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@types/jest": "^29.5.14",
+        "@typescript-eslint/eslint-plugin": "^8.58.0",
+        "@typescript-eslint/parser": "^8.58.0",
         "esbuild": "^0.28.0",
+        "eslint": "^10.2.0",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-prettier": "^5.5.5",
+        "globals": "^17.4.0",
         "jest": "^29.7.0",
+        "prettier": "^3.8.1",
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.0",
-        "typescript": "^5.4.0"
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.58.0"
       }
     },
     "node_modules/@babel/code-frame": {


### PR DESCRIPTION
##  O que este PR resolve?
Este PR resolve a **Issue  Closes #42**, corrigindo o problema de  palavras/frases contendo conteúdo tóxico e bypass (leetspeak/símbolos) que estavam passando pelo filtro.  Closes #37, Closes #36

##  O que foi alterado?
- **Sincronização de Wordlists:** Adicionados os termos base faltantes no `HARD_BLOCKED` (ex: pornografia, tarado, cuzinho, gozo, sexo) e no `CONTEXT_SENSITIVE` (ex: adulto, leite, jogar).
- **Refinamento do Normalizador (Layer 0):** O motor agora converte corretamente os símbolos `@` para `a` e `!` para `i` antes da validação, barrando tentativas de ofuscação como `p0rn0gr@f14` e `cuz!nh0`.
- **Expansão de Inteligência:** Inclusão de novas `SEXUAL_SEED_WORDS` e mapeamento de abreviações (`prn`, `sx`, `trd`).
- **Limpeza de Código:** Removidas duplicatas (ex: "tarada") e corrigidos os warnings apontados pelo script de validação.