### PR TITLE
feat: add long phrase examples to Playground

### DIFF
--- a/website/src/components/Examples.tsx
+++ b/website/src/components/Examples.tsx
@@ -1,10 +1,11 @@
-import './Examples.css'
+import './Examples.css';
 
 interface ExamplesProps {
-  onSelect: (text: string) => void
+  onSelect: (text: string) => void;
 }
 
 const examples = [
+  // — Exemplos curtos —
   { text: 'eu me sinto um lixo', type: 'safe' as const },
   { text: 'voce e um lixo', type: 'toxic' as const },
   { text: '3stupr0', type: 'bypass' as const },
@@ -17,14 +18,41 @@ const examples = [
   { text: 'preciso de ajuda', type: 'safe' as const },
   { text: 'ppk', type: 'bypass' as const },
   { text: 'pau de selfie', type: 'safe' as const },
-]
+
+  // — Exemplos longos (frases realistas) —
+  {
+    text: 'eu me sinto um lixo mas queria que voce me respeitasse',
+    label: 'Context-aware (auto-expressão)',
+    type: 'safe' as const,
+  },
+  {
+    text: 'acordei com o pau veiudo saco lotado de tanto leite',
+    label: 'Seed density (palavras ambíguas)',
+    type: 'toxic' as const,
+  },
+  {
+    text: 'ela engolia tudo, mamou muito, joguei o leite na boca dela',
+    label: 'Narrativa sexual longa',
+    type: 'toxic' as const,
+  },
+  {
+    text: 'caralho tiozao tu ta de brincadeira, voce e um lixo cara',
+    label: 'Insulto + exclamação misturados',
+    type: 'toxic' as const,
+  },
+  {
+    text: '3stupr0 v.i.a.d.o p*ta',
+    label: 'Bypass (leetspeak + pontos + censura)',
+    type: 'bypass' as const,
+  },
+];
 
 export default function Examples({ onSelect }: ExamplesProps) {
   const handleClick = (text: string) => {
-    const setter = (window as any).__scannerSetText
-    if (setter) setter(text)
-    else onSelect(text)
-  }
+    const setter = (window as any).__scannerSetText;
+    if (setter) setter(text);
+    else onSelect(text);
+  };
 
   return (
     <section className="examples-section">
@@ -32,11 +60,7 @@ export default function Examples({ onSelect }: ExamplesProps) {
         <h3 className="examples-title">Exemplos para testar</h3>
         <div className="examples-grid">
           {examples.map((ex, i) => (
-            <button
-              key={i}
-              className="example-chip"
-              onClick={() => handleClick(ex.text)}
-            >
+            <button key={i} className="example-chip" onClick={() => handleClick(ex.text)}>
               <span className={`example-dot ${ex.type}`} />
               <span className="example-text">{ex.label || ex.text}</span>
             </button>
@@ -44,5 +68,5 @@ export default function Examples({ onSelect }: ExamplesProps) {
         </div>
       </div>
     </section>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- Adds 5 realistic long-phrase examples to the Playground `Examples.tsx` component (closes #38)
- Examples cover: **context-aware** (auto-expressão), **seed density**, **narrativa sexual**, **insulto + exclamação**, and **bypass** (leetspeak + pontos + censura)
- Each example has a descriptive label and correct dot color (green/red/yellow)

## Test plan
- [x] All 861 tests pass
- [x] Formatter applied
- [ ] Verify examples render correctly in the Playground UI
- [ ] Confirm each example produces the expected result (safe/toxic/bypass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)