### PR TITLE
fix: normalizar espaços entre caracteres isolados

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -168,7 +168,18 @@ export function normalize(input: string): string {
   t = t.replace(/(\w)[.\-](\w)/g, '$1$2');
 
   // 9. Remove spaces between isolated single chars (p u t a → puta)
-  t = t.replace(/\b(\w)\s(\w)\s(\w)/g, (_, a, b, c) => a + b + c);
+
+  const blocklist = new Set([...HARD_BLOCKED]);
+
+  t = t.replace(/\b(?:[a-z]\s*){3,}\b/gi, (match) => {
+  const normalizada = match.replace(/\s+/g, "").toLowerCase();
+
+    if (blocklist.has(normalizada)) {
+      return normalizada; // ou "***", ou bloquear como quiser
+    }
+
+    return match;
+  });
 
   // 10. Expand known abbreviations (strip punctuation from each word before lookup)
   const words = t.split(/\s+/);


### PR DESCRIPTION
#25

Corrige o seguinte:

- g ozar
- m acac  o
- mam ada 
- bu ceta
- est upro 
- p u t a 

Não consegui consertar o "arrom bado", ele está normalizando para "arom bado" e por isso não reconhece, apesar de que se vc digitar "arombado" ele reconhece e bloqueia, então só teria que retirar esse espaço do meio, mas quanto mais eu tento mexer mais quebra, então resolvi deixar assim. A verificação foi feita somente com as palavras isoladas, não no meio de frases.

