### PR TITLE
feat: adiciona 'paquita do olodum' como termo racista bloqueado

### DIFF
--- a/__tests__/filter.test.ts
+++ b/__tests__/filter.test.ts
@@ -92,6 +92,30 @@ describe('hard-blocked — racism terms', () => {
     expect(result.allowed).toBe(false);
     if (!result.allowed) expect(result.reason).toBe('hard_block');
   });
+
+  it('blocks "paquita do olodum"', () => {
+    const result = filterContent('você é uma paquita do olodum');
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) expect(result.reason).toBe('hard_block');
+  });
+
+  it('blocks "paquita do olodum" com leetspeak (p@quit@ d0 0l0dum)', () => {
+    const result = filterContent('p@quit@ d0 0l0dum');
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) expect(result.reason).toBe('hard_block');
+  });
+
+  it('blocks "paquita do olodum" com zero-width char dentro da palavra', () => {
+    const result = filterContent('paqu\u200Bita do olo\u200Bdum');
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) expect(result.reason).toBe('hard_block');
+  });
+
+  it('blocks "paquita do olodum" com acentos incomuns', () => {
+    const result = filterContent('pàquita dô ölodùm');
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) expect(result.reason).toBe('hard_block');
+  });
 });
 
 // ─── New slurs added in v2 ───────────────────────────────────────────────────

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -341,6 +341,7 @@ const FUZZY_ALLOWLIST = new Set([
   'transe', // → causing false positive in "Terra em Transe" (fuzzy match com "transar")
   'bicho', // → causing false positives in: "O Bicho vai Pegar", "Bicho de Sete Cabeças" (fuzzy match com "bichona")
   'lambs', // -> causing false positives in: "The Silence of the Lambs" (fuzzy match com "lamber")
+  'asasins', // → causing false positive in "Assassins Creed" (fuzzy match com "assassina")
 ]);
 
 // ─── PT-BR Stemmer (RSLP simplificado) ──────────────────────────────────────

--- a/src/wordlists.ts
+++ b/src/wordlists.ts
@@ -361,6 +361,7 @@ export const HARD_BLOCKED: string[] = [
   'preto imundo', 'preta imunda',
   'bola gato',
   'mascote de petrolifera',
+  'paquita do olodum',
 
   // ── Nazismo / fascismo / supremacia ──
   'nazi', 'nazista', 'nazismo', 'neonazi', 'neonazista', 'neonazismo',


### PR DESCRIPTION
## Contexto

Closes #77

O termo **"paquita do olodum"** foi sugerido pela comunidade via o site do ToxiBR. Ao ser testado no playground, a frase passava como conteúdo limpo, permitindo seu uso como insulto racista.

## O que foi feito

### `src/wordlists.ts`
- Adicionado `'paquita do olodum'` ao array `HARD_BLOCKED` na seção de racismo.

### `__tests__/filter.test.ts`
- Adicionado teste principal verificando que a frase é bloqueada.
- Adicionados testes de bypass para garantir que o pipeline de normalização já existente cobre tentativas de evasão:
  - **Leetspeak**: `p@quit@ d0 0l0dum`
  - **Zero-width chars** dentro das palavras: `paqu\u200Bita do olo\u200Bdum`
  - **Acentos incomuns**: `pàquita dô ölodùm`

### `src/filter.ts` (correção de falso positivo pré-existente)
- O teste `allows "Assassins Creed"` estava falhando antes desta PR. A palavra "Assassins" normaliza para `asasins` (repetições colapsadas), que gerava um fuzzy match incorreto com `assassina`.
- Adicionado `'asasins'` à `FUZZY_ALLOWLIST`, seguindo o mesmo padrão dos outros títulos de filmes já presentes na lista.

## Testes

Todos os 1314 testes passando após as alterações.