### PR TITLE
feat: adiciona 'cu de ampola' como slur/ofensa grave bloqueada

### DIFF
--- a/__tests__/filter.test.ts
+++ b/__tests__/filter.test.ts
@@ -94,6 +94,34 @@ describe('hard-blocked — racism terms', () => {
   });
 });
 
+// ─── Slurs / ofensas graves — frases ─────────────────────────────────────────
+
+describe('hard-blocked — slur phrases', () => {
+  it('blocks "cu de ampola"', () => {
+    const result = filterContent('você é um cu de ampola');
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) expect(result.reason).toBe('hard_block');
+  });
+
+  it('blocks "cu de ampola" com leetspeak (cu d3 4mp0la)', () => {
+    const result = filterContent('cu d3 4mp0la');
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) expect(result.reason).toBe('hard_block');
+  });
+
+  it('blocks "cu de ampola" com zero-width char dentro da palavra', () => {
+    const result = filterContent('cu de am\u200Bpola');
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) expect(result.reason).toBe('hard_block');
+  });
+
+  it('blocks "cu de ampola" com acentos incomuns', () => {
+    const result = filterContent('cu dê àmpola');
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) expect(result.reason).toBe('hard_block');
+  });
+});
+
 // ─── New slurs added in v2 ───────────────────────────────────────────────────
 
 describe('hard-blocked — new slurs (v2)', () => {

--- a/src/wordlists.ts
+++ b/src/wordlists.ts
@@ -90,6 +90,7 @@ export const HARD_BLOCKED: string[] = [
   'quenga',
   'rapariga', 'rameira', 'meretriz',
   'vacilao',
+  'cu de ampola',
 
   // ── Abreviacoes BR comuns ──
   'ppk', 'pqp', 'gzr', 'bct', 'pnht',


### PR DESCRIPTION
## Contexto

Closes #79

O termo **"cu de ampola"** foi sugerido pela comunidade via o site do ToxiBR. A frase estava sendo usada para ofender outros usuários e não era detectada pelo filtro.

## O que foi feito

### `src/wordlists.ts`
- Adicionado `'cu de ampola'` ao array `HARD_BLOCKED` na seção `// ── Slurs / ofensas graves ──`.

### `__tests__/filter.test.ts`
- Adicionado bloco de testes `hard-blocked — slur phrases` cobrindo a frase e tentativas de bypass:
  - **Caso base**: `'você é um cu de ampola'`
  - **Leetspeak**: `'cu d3 4mp0la'`
  - **Zero-width chars** dentro da palavra: `'cu de am\u200Bpola'`
  - **Acentos incomuns**: `'cu dê àmpola'`

## Testes

Todos os 4 novos testes passando. O pipeline de normalização já existente cobre todas as tentativas de bypass testadas.