### PR TITLE
chore: unify workspace formatting defaults for contributors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 100

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ dist
 .env.*
 *.log
 .DS_Store
-.vscode/
 .idea/
 coverage/
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "esbenp.prettier-vscode"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
+  "files.eol": "\n",
+  "prettier.configPath": ".prettierrc",
+  "prettier.useEditorConfig": true
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,13 @@ O script `scripts/validate-wordlists.ts` verifica:
 
 O CI roda isso automaticamente em todo PR.
 
+## Setup do editor (VS Code / Cursor)
+
+Para manter a formatação consistente (Prettier/ESLint) e reduzir ruído no diff, instale as **extensões recomendadas do workspace**:
+
+- Ao abrir o projeto, aceite o prompt de **instalar as extensões recomendadas**.
+- Alternativamente, abra a aba de Extensões e procure por **Recomendadas** (workspace) ou use o comando **“Extensions: Show Recommended Extensions”**.
+
 ## Checklist do PR
 
 - [ ] Palavra em lowercase, sem acentos


### PR DESCRIPTION
## Summary

This PR standardizes editor/workspace formatting behavior to reduce accidental noisy diffs while contributing from different branches.

- Adds a root .editorconfig aligned with Prettier rules (2 spaces, LF, final newline, max line length 100).
- Adds workspace VS Code settings to run Prettier on save using the project config.
- Updates CONTRIBUTING.md with guidance to install recommended workspace extensions.

## Context

While contributing in other branches, this formatting gap sometimes caused poorly formatted code to be committed, or my editor default settings reformatted files unexpectedly and changed large parts of the codebase.

This PR aims to make formatting behavior consistent across contributors and branches.

## Validation

- Confirmed workspace settings and editorconfig are tracked in the repository.
- CONTRIBUTING.md now documents extension setup for contributors.
